### PR TITLE
Crawler instance has no attribute 'pool'

### DIFF
--- a/pysitemap/crawler.py
+++ b/pysitemap/crawler.py
@@ -43,7 +43,7 @@ class Crawler:
     def crawl(self, echo=False, pool_size=1):
         self.echo = echo
         self.regex = re.compile(self.allowed_regex)
-        if gevent_installed and pool_size > 1:
+        if gevent_installed and pool_size >= 1:
             self.pool = pool.Pool(pool_size)
             self.pool.spawn(self.parse_gevent)
             self.pool.join()


### PR DESCRIPTION
Default value for `pool_size` is `1` but I got error:

```
print('{} pages parsed :: {} parsing processes  :: {} pages in the queue'.format(len(self.visited), len(self.pool), len(self.urls)))
AttributeError: Crawler instance has no attribute 'pool'
```

Because `pool_size` must be more then 1
https://github.com/Haikson/sitemap-generator/blob/3ab04f6da011ebd31e4a8255ca9f4d0b380f65d4/pysitemap/crawler.py#L46

#### So, we need to change default value for `pool_size` to 2 or to approve my commit.